### PR TITLE
Add argument for setting output file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ $ref: "./order.yaml"
 merger -f index.yml
 ```
 (index.yml is just a file name in example)
+
+#### You can optionally specify an output filename with the -o argument, the default is swagger.yml
+
+```
+merger -f index.yml -o output.yml
+```

--- a/swagger_merger/src/cli.py
+++ b/swagger_merger/src/cli.py
@@ -5,6 +5,7 @@ import swagger_merger
 def main():
     parser = argparse.ArgumentParser(prog='merger',
                                      description='swagger merger package.')
-    parser.add_argument('-f')
+    parser.add_argument('-f', dest="input_file", help='Name of the input file')
+    parser.add_argument('-o', dest="output_file", help='Name of the output file')
     args = parser.parse_args()
-    swagger_merger.merge(args.f, ".", "swagger.yml", ".")
+    swagger_merger.merge(args.input_file, ".", args.output_file, ".")


### PR DESCRIPTION
Hello, I found this project to be helpful for managing my openapi specs, and just wanted to quickly add in functionality for specifying an output file name to prevent having to rename manually. Thanks!